### PR TITLE
stop_stream_data() error

### DIFF
--- a/examples/phasemeter_plotting.py
+++ b/examples/phasemeter_plotting.py
@@ -95,7 +95,7 @@ try:
         plt.pause(0.001)
         plt.draw()
 
-        i.stop_stream_data()
+    i.stop_stream_data()
 
 except StreamException as e:
     print("Error occured: %s" % e)


### PR DESCRIPTION
The i.stop_stream_data() was improperly indented and cause the while loop to fail after one iteration. The simple fix allows the example to run. 